### PR TITLE
Updated SFINAE test for method 'parse'

### DIFF
--- a/code/core/inc/ForceModel.hpp
+++ b/code/core/inc/ForceModel.hpp
@@ -37,7 +37,7 @@ struct HasParse
 {
     typedef char yes[1];
     typedef char no [2];
-    template<typename U> static yes &check(typeof(&U::parse)*);
+    template<typename U> static yes &check(decltype(&U::parse));
     template<typename U> static no &check(...);
     static const bool value = sizeof(check<T>(0)) == sizeof(yes);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed typeof()* to decltype() in SFINAE test for method 'parse'. The previous version triggered an error while trying to build with Code::Blocks on Debian 10 using GCC 8.3.0

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #3 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This version uses the C++11 `decltype` instead of the GCC-specific `typeof`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After this change the error did not occur anymore. Testing is expected from Travis-CI before accepting this commit.
