### PR TITLE
Bug correction for issue #5

### DIFF
--- a/code/core/inc/ForceModel.hpp
+++ b/code/core/inc/ForceModel.hpp
@@ -37,7 +37,7 @@ struct HasParse
 {
     typedef char yes[1];
     typedef char no [2];
-    template<typename U> static yes &check(typeof(&U::parse)*);
+    template<typename U> static yes &check(decltype(&U::parse));
     template<typename U> static no &check(...);
     static const bool value = sizeof(check<T>(0)) == sizeof(yes);
 };

--- a/code/core/src/ControllableForceModel.cpp
+++ b/code/core/src/ControllableForceModel.cpp
@@ -121,19 +121,19 @@ void ControllableForceModel::feed(Observer& observer, ssc::kinematics::Kinematic
     const auto force_in_ned_frame_at_O = rot_from_body_frame_to_ned*tau_in_body_frame_at_G.force;
     const auto torque_in_ned_frame_at_O = rot_from_body_frame_to_ned*(tau_in_body_frame_at_G.torque+OG.cross(tau_in_body_frame_at_G.force));;
 
-    observer.write(tau_in_body_frame_at_G.X(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fx"},std::string("Fx(")+name+","+body_name+","+body_name+")"));
-    observer.write(tau_in_body_frame_at_G.Y(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fy"},std::string("Fy(")+name+","+body_name+","+body_name+")"));
-    observer.write(tau_in_body_frame_at_G.Z(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fz"},std::string("Fz(")+name+","+body_name+","+body_name+")"));
-    observer.write(tau_in_body_frame_at_G.K(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Mx"},std::string("Mx(")+name+","+body_name+","+body_name+")"));
-    observer.write(tau_in_body_frame_at_G.M(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"My"},std::string("My(")+name+","+body_name+","+body_name+")"));
-    observer.write(tau_in_body_frame_at_G.N(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Mz"},std::string("Mz(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.X(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fx"},std::string("Fx(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.Y(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fy"},std::string("Fy(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.Z(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fz"},std::string("Fz(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.K(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Mx"},std::string("Mx(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.M(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"My"},std::string("My(")+name+","+body_name+","+body_name+")"));
+    observer.write(tau_in_body_frame_at_G.N(),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Mz"},std::string("Mz(")+name+","+body_name+","+body_name+")"));
 
-    observer.write((double)force_in_internal_frame_at_P(0),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fx"},std::string("Fx(")+name+","+body_name+","+name+")"));
-    observer.write((double)force_in_internal_frame_at_P(1),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fy"},std::string("Fy(")+name+","+body_name+","+name+")"));
-    observer.write((double)force_in_internal_frame_at_P(2),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Fz"},std::string("Fz(")+name+","+body_name+","+name+")"));
-    observer.write((double)torque_in_internal_frame_at_P(0),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Mx"},std::string("Mx(")+name+","+body_name+","+name+")"));
-    observer.write((double)torque_in_internal_frame_at_P(1),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"My"},std::string("My(")+name+","+body_name+","+name+")"));
-    observer.write((double)torque_in_internal_frame_at_P(2),DataAddressing(std::vector<std::string>{"efforts",body_name,name,body_name,"Mz"},std::string("Mz(")+name+","+body_name+","+name+")"));
+    observer.write((double)force_in_internal_frame_at_P(0),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fx"},std::string("Fx(")+name+","+body_name+","+name+")"));
+    observer.write((double)force_in_internal_frame_at_P(1),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fy"},std::string("Fy(")+name+","+body_name+","+name+")"));
+    observer.write((double)force_in_internal_frame_at_P(2),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Fz"},std::string("Fz(")+name+","+body_name+","+name+")"));
+    observer.write((double)torque_in_internal_frame_at_P(0),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Mx"},std::string("Mx(")+name+","+body_name+","+name+")"));
+    observer.write((double)torque_in_internal_frame_at_P(1),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"My"},std::string("My(")+name+","+body_name+","+name+")"));
+    observer.write((double)torque_in_internal_frame_at_P(2),DataAddressing(std::vector<std::string>{"efforts",body_name,name,name,"Mz"},std::string("Mz(")+name+","+body_name+","+name+")"));
 
     observer.write((double)force_in_ned_frame_at_O(0),DataAddressing(std::vector<std::string>{"efforts",body_name,name,"NED","Fx"},std::string("Fx(")+name+","+body_name+",NED)"));
     observer.write((double)force_in_ned_frame_at_O(1),DataAddressing(std::vector<std::string>{"efforts",body_name,name,"NED","Fy"},std::string("Fy(")+name+","+body_name+",NED)"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes to the Observer writing path : there was an inversion between the frames in the Observer.write instructions.
For example requesting to output the force 'Fx(force_name,body_name,body_name)' (for a controlled force) would write in the observer the Fx component of force_name acting on body_name and projected in the body_name frame, but with the path /efforts/body_name/force_name/force_name instead of the path /efforts/body_name/force_name/body_name. Conversely, requiring to output 'Fx(force_name,body_name,force_name)' would write the Fx component of force_name acting on body_name in the local frame associated with force_name, but with the path /efforts/body_name/force_name/body_name instead of /efforts/body_name/force_name/force_name.

## Related Issue
https://github.com/sirehna/xdyn/issues/5

## How Has This Been Tested?
Tested on my own machine.
