### PR TITLE
Radiation damping force model correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build*64
 build_debian
 build_deb8
 build_deb9
+build_deb10*
 build_windows
 build_win_posix
 code/build_*

--- a/code/.gitignore
+++ b/code/.gitignore
@@ -7,3 +7,4 @@ RemoteSystemsTempFiles
 debug
 profile
 release
+yaml-cpp

--- a/code/force_models/src/RadiationDampingForceModel.cpp
+++ b/code/force_models/src/RadiationDampingForceModel.cpp
@@ -131,11 +131,12 @@ class RadiationDampingForceModel::Impl
             return builder.build_retardation_function(Br,taus,1E-3,omega.front(),omega.back());
         }
 
-        double get_convolution_for_axis(const size_t i, const History& his)
+        double get_convolution_for_axis(const size_t i, const BodyStates& states)
         {
             double K_X_dot = 0;
             for (size_t k = 0 ; k < 6 ; ++k)
             {
+            	const History his = get_velocity_history_from_index(k, states);
                 if (his.get_duration() >= Tmin)
                 {
                     // Integrate up to Tmax if possible, but never exceed the history length
@@ -146,17 +147,31 @@ class RadiationDampingForceModel::Impl
             return K_X_dot;
         }
 
+        History get_velocity_history_from_index(const size_t i, const BodyStates& states) const
+        {
+        	switch(i)
+        	{
+        		case 0: return states.u;
+        		case 1: return states.v;
+        		case 2: return states.w;
+        		case 3: return states.p;
+        		case 4: return states.q;
+        		case 5: return states.r;
+        		default: return History();
+        	}
+        }
+
         ssc::kinematics::Wrench get_wrench(const BodyStates& states)
         {
             ssc::kinematics::Vector6d W;
             const ssc::kinematics::Point H(states.name,H0);
 
-            W(0) = -get_convolution_for_axis(0, states.u);
-            W(1) = -get_convolution_for_axis(1, states.v);
-            W(2) = -get_convolution_for_axis(2, states.w);
-            W(3) = -get_convolution_for_axis(3, states.p);
-            W(4) = -get_convolution_for_axis(4, states.q);
-            W(5) = -get_convolution_for_axis(5, states.r);
+            W(0) = -get_convolution_for_axis(0, states);
+            W(1) = -get_convolution_for_axis(1, states);
+            W(2) = -get_convolution_for_axis(2, states);
+            W(3) = -get_convolution_for_axis(3, states);
+            W(4) = -get_convolution_for_axis(4, states);
+            W(5) = -get_convolution_for_axis(5, states);
             return ssc::kinematics::Wrench(states.name,W);
         }
 

--- a/code/observers_and_api/unit_tests/src/SimTest.cpp
+++ b/code/observers_and_api/unit_tests/src/SimTest.cpp
@@ -559,7 +559,7 @@ TEST_F(SimTest, LONG_can_simulate_radiation_damping)
     command_listener.set<double>("propeller(beta)", 0.8);
     command_listener.check_out();
     const auto res = simulate<ssc::solver::RK4Stepper>(test_data::test_ship_radiation_damping(), test_data::cube(), 0, T, dt, command_listener);
-    ASSERT_NEAR(0.65842512818042176, res.at(5).x[XIDX(0)], 1E-3);
+    ASSERT_NEAR(0.64349959510185351, res.at(5).x[XIDX(0)], 1E-3);
 }
 
 TEST_F(SimTest, bug_2963_should_not_be_able_to_use_fast_hydrostatic_without_specifying_wave_model)


### PR DESCRIPTION
## Description
The matrix multiplication was modified to actually be a matrix multiplication, which it was not beforehand.

## Related Issue
See Issue #9

## Motivation and Context
In addition to being mathematically wrong, the error in the force model caused some simulations to diverge quite severely.

## How Has This Been Tested?
This hasn't really been tested as the change is trivial. A proper unit test should be added for this force model that highlights the issue. However because the force model violates the Single Responsibility principle, implementing a test that pinpoints the issue is quite complicated.
